### PR TITLE
fix(scan): Production-ready improvements to scan-images.sh i nthe supply-chain-practices

### DIFF
--- a/supply-chain-practices/scan-images.sh
+++ b/supply-chain-practices/scan-images.sh
@@ -1,17 +1,86 @@
 #!/bin/bash
+set -euo pipefail
+
+# ─── Configuration ───────────────────────────────────────────
 IMAGES=("node:16-alpine" "python:3.9-slim" "nginx:alpine")
 DATE=$(date +%Y%m%d)
+OUTPUT_DIR="./scan-results/${DATE}"
+SEVERITY_THRESHOLD="HIGH,CRITICAL"
+EXIT_CODE=0
 
-for image in "${IMAGES[@]}"; do
-    echo "Scanning $image..."
-    trivy image --format json "$image" > "${image//[:\/]/_}-scan-$DATE.json"
+# ─── Dependency Check ────────────────────────────────────────
+if ! command -v trivy &>/dev/null; then
+    echo "ERROR: trivy is not installed. https://aquasecurity.github.io/trivy"
+    exit 1
+fi
 
-    CRITICAL_COUNT=$(trivy image --severity CRITICAL --format json "$image" | \
-      jq '[.Results[].Vulnerabilities[]] | length' 2>/dev/null || echo "0")
+if ! command -v jq &>/dev/null; then
+    echo "ERROR: jq is not installed."
+    exit 1
+fi
 
-    if [ "$CRITICAL_COUNT" -gt 0 ]; then
-        echo "WARNING: $image has $CRITICAL_COUNT critical vulnerabilities!"
+mkdir -p "${OUTPUT_DIR}"
+
+# ─── Update DB once before scanning ──────────────────────────
+echo "[*] Updating Trivy vulnerability database..."
+trivy image --download-db-only --quiet
+
+# ─── Scan Function ───────────────────────────────────────────
+scan_image() {
+    local image="$1"
+    local safe_name="${image//[:\/]/_}"
+    local json_out="${OUTPUT_DIR}/${safe_name}-scan-${DATE}.json"
+    local sarif_out="${OUTPUT_DIR}/${safe_name}-scan-${DATE}.sarif"
+
+    echo ""
+    echo "══════════════════════════════════════════"
+    echo "  Scanning: ${image}"
+    echo "══════════════════════════════════════════"
+
+    trivy image \
+        --format json \
+        --output "${json_out}" \
+        --scanners vuln,secret \
+        --quiet \
+        "${image}"
+
+    trivy image \
+        --format sarif \
+        --output "${sarif_out}" \
+        --severity "${SEVERITY_THRESHOLD}" \
+        --ignore-unfixed \
+        --quiet \
+        "${image}"
+
+    local critical high medium
+    critical=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' "${json_out}" 2>/dev/null || echo 0)
+    high=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' "${json_out}" 2>/dev/null || echo 0)
+    medium=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="MEDIUM")] | length' "${json_out}" 2>/dev/null || echo 0)
+
+    echo "  CRITICAL : ${critical}"
+    echo "  HIGH     : ${high}"
+    echo "  MEDIUM   : ${medium}"
+    echo "  Report   : ${json_out}"
+
+    if [ "${critical}" -gt 0 ]; then
+        echo "  ⚠️  WARNING: ${critical} CRITICAL vulnerabilities in ${image}!"
+        EXIT_CODE=1
+    elif [ "${high}" -gt 0 ]; then
+        echo "  ⚠️  WARNING: ${high} HIGH vulnerabilities in ${image}!"
     else
-        echo "OK: $image - no critical vulnerabilities"
+        echo "  ✅ OK: No CRITICAL/HIGH vulnerabilities found."
     fi
+}
+
+# ─── Run Scans ───────────────────────────────────────────────
+for image in "${IMAGES[@]}"; do
+    scan_image "${image}"
 done
+
+# ─── Summary ─────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════"
+echo "  Scan complete. Results in: ${OUTPUT_DIR}"
+echo "══════════════════════════════════════════"
+
+exit "${EXIT_CODE}"


### PR DESCRIPTION
## What & Why
Refactored `scan-images.sh` to fix reliability issues and align with Trivy best practices.

## Changes Summary

| Area             | Before            | After                        |
|------------------|-------------------|------------------------------|
| Error handling   | None              | `set -euo pipefail`          |
| Dependency check | None              | Checks trivy + jq on startup |
| DB update        | Every scan        | Once before loop             |
| Output location  | Root dir          | `scan-results/YYYYMMDD/`     |
| Severity tracked | CRITICAL only     | CRITICAL + HIGH + MEDIUM     |
| Output formats   | JSON only         | JSON + SARIF per image       |
| CI exit code     | Always 0          | 1 on CRITICAL findings       |
| Secret scanning  | Disabled          | Enabled (vuln,secret)        |

## How to Test
```bash
chmod +x scan-images.sh
./scan-images.sh
echo "Exit code: $?"  # 1 if CRITICAL found, 0 if clean
ls scan-results/      # Organized by date
```